### PR TITLE
Add 'from' attribute to 'selection' elements

### DIFF
--- a/src/xml/schema/vNext/Catalogue.xsd
+++ b/src/xml/schema/vNext/Catalogue.xsd
@@ -312,6 +312,13 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="SelectionFromKind">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="group"/>
+      <xs:enumeration value="entry"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <!--selection entry group-->
   <xs:complexType name="SelectionEntryGroup">
     <xs:complexContent>
@@ -669,6 +676,7 @@
         </xs:sequence>
         <xs:attribute name="number" type="xs:nonNegativeInteger" use="required" />
         <xs:attribute name="type" type="tns:SelectionEntryKind" use="required" />
+        <xs:attribute name="from" type="tns:SelectionFromKind" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>


### PR DESCRIPTION
This should be used in roster files to note whether a given selection came from a selection entry or a selection group.

Needed to address https://github.com/BSData/wh40k-10e/issues/393.

Note that, if applied only in roster files, this change does not break Battlescribe compatibility: the BS roster editor, unlike the data editor, is permissive of unrecognized attributes.